### PR TITLE
[Fix] headerTab index 바뀌는 것 수정

### DIFF
--- a/apps/web/app/store/useDateStore.ts
+++ b/apps/web/app/store/useDateStore.ts
@@ -118,7 +118,7 @@ export const useDateStore = create<DateStore>((set) => ({
   handleNextMonth: () => {
     set((state) => {
       let { year, month, day } = state.selectedDate;
-      const currentMonth = new Date().getMonth() + 1; // 현재 월
+      const currentMonth = new Date().getMonth() + 1;
 
       month += 1;
 
@@ -132,7 +132,6 @@ export const useDateStore = create<DateStore>((set) => ({
       }
 
       const { dayOfWeek } = calculateNewDate(year, month, day);
-
       return {
         selectedDate: { ...state.selectedDate, year, month, day, dayOfWeek },
       };

--- a/apps/web/components/Header/HeaderTabs.tsx
+++ b/apps/web/components/Header/HeaderTabs.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import cn from "@ui/src/utils/cn";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { motion } from "framer-motion";
 import { formatDate, getDatesForSeats, getDatesFromTodayToEndOfMonth } from "@ui/src/utils/date";
 import { useDateStore } from "@/app/store/useDateStore";
@@ -28,45 +28,60 @@ export default function HeaderTabs({ page }: HeaderProps): JSX.Element {
     }
   };
 
+  useEffect(() => {
+    setActiveTabIndex(0);
+  }, [selectedDate.month]);
+
+  const today = new Date();
+  const isCurrentMonth = selectedDate.year === today.getFullYear() && selectedDate.month === today.getMonth() + 1;
+
   return (
-    <div className="h-45 scrollbar-hidden relative top-4 flex items-end gap-24 overflow-auto md:static">
-      {dates.map((date, index) => (
-        <motion.div
-          key={String(date)}
-          className="flex min-w-fit cursor-pointer flex-col gap-16"
-          onClick={() => {
-            handleActiveTab(index);
-          }}
-          role="tab"
-          aria-selected={activeTabIndex === index}
-          tabIndex={0}
-          whileHover={activeTabIndex !== index ? { scale: 0.96 } : {}}
-          transition={{ duration: 0.2 }}
-        >
-          <motion.span
-            className={cn({
-              "text-text-default": activeTabIndex !== index,
-              "text-text-inverse font-bold": activeTabIndex === index,
-            })}
-            animate={{
-              color: activeTabIndex === index ? "#6500C2" : "#c3c7cc",
+    <>
+      {isCurrentMonth ? (
+        <span className="text-10 rounded-8 absolute bg-[#EB008D] px-4 py-2 text-center font-medium text-white">
+          오늘
+        </span>
+      ) : null}
+
+      <div className="scrollbar-hidden h-69 relative top-4 flex items-end gap-24 overflow-auto md:static">
+        {dates.map((date, index) => (
+          <motion.div
+            key={String(date)}
+            className="flex min-w-fit cursor-pointer flex-col gap-16"
+            onClick={() => {
+              handleActiveTab(index);
             }}
-            whileHover={activeTabIndex !== index ? { color: "#6500C2" } : {}}
+            role="tab"
+            aria-selected={activeTabIndex === index}
+            tabIndex={0}
+            whileHover={activeTabIndex !== index ? { scale: 0.96 } : {}}
             transition={{ duration: 0.2 }}
           >
-            {formatDate(date, page)}
-          </motion.span>
-          <motion.span
-            className="w-full border-b-2 border-solid"
-            initial={{ scaleX: 0 }}
-            animate={{
-              scaleX: activeTabIndex === index ? 1 : 0,
-              borderColor: activeTabIndex === index ? "#6500C2" : "rgba(255, 255, 255, 0)",
-            }}
-            transition={{ duration: 0.3 }}
-          />
-        </motion.div>
-      ))}
-    </div>
+            <motion.span
+              className={cn({
+                "text-text-default": activeTabIndex !== index,
+                "text-text-inverse font-bold": activeTabIndex === index,
+              })}
+              animate={{
+                color: activeTabIndex === index ? "#6500C2" : "#c3c7cc",
+              }}
+              whileHover={activeTabIndex !== index ? { color: "#6500C2" } : {}}
+              transition={{ duration: 0.2 }}
+            >
+              {formatDate(date, page)}
+            </motion.span>
+            <motion.span
+              className="w-full border-b-2 border-solid"
+              initial={{ scaleX: 0 }}
+              animate={{
+                scaleX: activeTabIndex === index ? 1 : 0,
+                borderColor: activeTabIndex === index ? "#6500C2" : "rgba(255, 255, 255, 0)",
+              }}
+              transition={{ duration: 0.3 }}
+            />
+          </motion.div>
+        ))}
+      </div>
+    </>
   );
 }

--- a/apps/web/components/Header/HeaderTabs.tsx
+++ b/apps/web/components/Header/HeaderTabs.tsx
@@ -3,7 +3,7 @@
 import cn from "@ui/src/utils/cn";
 import { useEffect, useState } from "react";
 import { motion } from "framer-motion";
-import { formatDate, getDatesForSeats, getDatesFromTodayToEndOfMonth } from "@ui/src/utils/date";
+import { formatDate, getDatesForSeats, getDatesFromTodayToEndOfMonth, isCurrentMonth } from "@ui/src/utils/date";
 import { useDateStore } from "@/app/store/useDateStore";
 
 interface HeaderProps {
@@ -28,16 +28,14 @@ export default function HeaderTabs({ page }: HeaderProps): JSX.Element {
     }
   };
 
+  const { month } = selectedDate;
   useEffect(() => {
     setActiveTabIndex(0);
-  }, [selectedDate.month]);
-
-  const today = new Date();
-  const isCurrentMonth = selectedDate.year === today.getFullYear() && selectedDate.month === today.getMonth() + 1;
+  }, [month]);
 
   return (
     <>
-      {isCurrentMonth ? (
+      {isCurrentMonth(selectedDate) ? (
         <span className="text-10 rounded-8 absolute bg-[#EB008D] px-4 py-2 text-center font-medium text-white">
           오늘
         </span>

--- a/apps/web/components/Header/index.tsx
+++ b/apps/web/components/Header/index.tsx
@@ -2,7 +2,6 @@
 
 import { Chevron, GearIcon } from "@ui/public";
 import Link from "next/link";
-import HeaderTabs from "./HeaderTabs";
 import { useDateStore } from "@/app/store/useDateStore";
 import HeaderTabs from "./HeaderTabs";
 
@@ -16,8 +15,8 @@ export default function Header({ page }: HeaderProps): JSX.Element {
   const isPrevMonthDisabled = selectedDate.year === today.getFullYear() && selectedDate.month === today.getMonth() + 1;
 
   return (
-    <div className="h-156 md:h-149 border-custom-black/20 pt-62 border-b border-solid bg-white pl-16 md:pl-64 md:pt-24">
-      <div className="flex">
+    <div className="h-176 md:h-149 border-custom-black/20 pt-62 border-b border-solid bg-white pl-16 md:pl-64 md:pt-24">
+      <div className="h-41 flex md:h-56">
         <h1 className="pr-13 !text-custom-black text-2xl-bold md:text-3xl-bold pb-13 md:pb-40 md:pr-24">
           {page === "meetings" ? "회의실 예약" : "좌석예약"}
         </h1>

--- a/packages/ui/src/utils/date.ts
+++ b/packages/ui/src/utils/date.ts
@@ -88,3 +88,14 @@ export const formatDate = (date: Date, page: string): string => {
 export const formatSelectedDate = (date: { year: number; month: number; day: number }): string => {
   return `${String(date.year)}-${String(date.month).padStart(2, "0")}-${String(date.day).padStart(2, "0")}`;
 };
+
+/**
+ * 제공된 연도와 월이 현재 연도와 월과 일치하는지 확인합니다.
+ *
+ * @param selectedDate - 확인할 연도와 월을 포함한 날짜 객체입니다.
+ * @returns - 선택한 날짜가 현재 연도와 월과 같으면 `true`를, 그렇지 않으면 `false`를 반환합니다.
+ */
+export const isCurrentMonth = (selectedDate: { year: number; month: number }): boolean => {
+  const today = new Date();
+  return selectedDate.year === today.getFullYear() && selectedDate.month === today.getMonth() + 1;
+};


### PR DESCRIPTION
Feat: 오늘 날짜에 뱃지 붙이기

## 🚀 작업 내용

- 월 바뀌었을때 탭인덱스 0번으로 바뀌게함
- 오늘 날짜에 뱃지붙임


## 📝 참고 사항

-

## 🖼️ 스크린샷


https://github.com/user-attachments/assets/63c9ae41-cf73-4687-afd7-29abfd38a4fd


## 🚨 관련 이슈 (이슈 번호)

- #

## ✅ 체크리스트

- [ ] Code Review 요청
- [ ] Label 설정
- [ ] PR 제목 규칙에 맞는지 확인


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **새로운 기능**
	- 선택한 날짜가 현재 월과 일치할 경우 "오늘" 레이블을 표시하는 기능 추가.
	- 선택한 날짜의 월이 변경될 때 활성 탭 인덱스를 0으로 재설정하는 로직 추가.
	- 현재 월을 확인하는 새로운 유틸리티 함수 추가.

- **버그 수정**
	- `useDateStore`에서 불필요한 줄 바꿈 제거로 코드 정리.

- **스타일**
	- 헤더의 높이를 조정하고 내부 요소의 스타일을 개선하여 레이아웃 향상.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->