### PR TITLE
[BE-Refactor] response 스키마 중첩구조로 변경, 예약 수정 컨트롤러 status 처리 로직 수정

### DIFF
--- a/apps/api/src/controllers/categoryController.ts
+++ b/apps/api/src/controllers/categoryController.ts
@@ -81,7 +81,7 @@ export const deleteCategory = async (req: Request<{ categoryId: string }>, res: 
   session.startTransaction();
 
   const itemIds = await Item.find({ category: categoryId }, { _id: 1 }).session(session);
-  const reservedItems = await Reservation.exists({ itemID: { $in: itemIds } }).session(session);
+  const reservedItems = await Reservation.exists({ item: { $in: itemIds } }).session(session);
   if (reservedItems) {
     await session.abortTransaction();
     await session.endSession();

--- a/apps/api/src/controllers/itemControllers.ts
+++ b/apps/api/src/controllers/itemControllers.ts
@@ -24,20 +24,20 @@ export const getAllItems = async (
   if (itemType) {
     switch (itemType) {
       case "room":
-        items = await Room.find();
+        items = await Room.find().populate("category", "name");
         break;
       case "seat":
-        items = await Seat.find();
+        items = await Seat.find().populate("category", "name");
         break;
       case "equipment":
-        items = await Equipment.find();
+        items = await Equipment.find().populate("category", "name");
         break;
       default:
         res.status(400).json({ message: "유효하지 않은 타입입니다." });
         return;
     }
   } else {
-    items = await Item.find();
+    items = await Item.find().populate("category", "name");
   }
   res.status(200).json(items);
 };

--- a/apps/api/src/controllers/itemControllers.ts
+++ b/apps/api/src/controllers/itemControllers.ts
@@ -27,7 +27,7 @@ export const getAllItems = async (
         items = await Room.find().populate("category", "name");
         break;
       case "seat":
-        items = await Seat.find().populate("category", "name");
+        items = await Seat.find();
         break;
       case "equipment":
         items = await Equipment.find().populate("category", "name");

--- a/apps/api/src/controllers/reservationControllers.ts
+++ b/apps/api/src/controllers/reservationControllers.ts
@@ -187,7 +187,7 @@ export const updateReservation = async (
   }
 
   const overlappingReservation = await isOverlappedReservation(
-    targetReservation.itemId,
+    targetReservation.item._id,
     finalStartAt,
     finalEndAt,
     targetReservation._id,

--- a/apps/api/src/controllers/reservationControllers.ts
+++ b/apps/api/src/controllers/reservationControllers.ts
@@ -14,7 +14,7 @@ import isObjectIdValid from "../utils/isObjectIdValid";
 interface ReservationRequestBody {
   userId: string;
   item: string;
-  itemType: string;
+  itemType: "room" | "seat" | "equipment";
   startAt: Date;
   endAt: Date;
   status?: TReservationStatus;
@@ -44,7 +44,7 @@ export const getUserReservations = async (
   const { startOfDay, endOfDay } = getStartAndEndOfDay(today);
 
   const userReservations: IReservation[] = await Reservation.find({
-    userId,
+    user: userId,
     startAt: { $gte: startOfDay, $lte: endOfDay },
   })
     .populate("user", "name email")
@@ -102,8 +102,8 @@ export const getReservationsByTypeAndDate = async (
 
   const reservations: IReservation[] = await Reservation.find(query)
     .populate("user", "name email")
-    .populate({ path: "item", model: itemTypeToModel[itemType], select: "name" })
     .populate("attendees", "name email")
+    .populate({ path: "item", select: "name", model: itemTypeToModel[itemType] })
     .sort({ status: 1, startAt: 1 });
 
   res.status(200).json(reservations);
@@ -174,6 +174,12 @@ export const updateReservation = async (
   const { reservationId } = req.params;
   const { startAt, endAt } = req.body;
   const status = req.body.status;
+
+  const allowedStatuses: TReservationStatus[] = ["reserved", "completed", "canceled"];
+  if (status && !allowedStatuses.includes(status)) {
+    res.status(400).json({ message: "유효하지 않은 상태 값입니다." });
+    return;
+  }
 
   // 예약 존재여부 확인
   const targetReservation: IReservation | null = await Reservation.findById(reservationId).select("startAt endAt item");

--- a/apps/api/src/controllers/reservationControllers.ts
+++ b/apps/api/src/controllers/reservationControllers.ts
@@ -13,7 +13,7 @@ import isObjectIdValid from "../utils/isObjectIdValid";
 
 interface ReservationRequestBody {
   userId: string;
-  itemId: string;
+  item: string;
   itemType: string;
   startAt: Date;
   endAt: Date;

--- a/apps/api/src/controllers/reservationControllers.ts
+++ b/apps/api/src/controllers/reservationControllers.ts
@@ -42,12 +42,15 @@ export const getUserReservations = async (
     startAt: { $gte: startOfDay, $lte: endOfDay },
   })
     .populate("user", "name email")
-    .populate([
-      { path: "item", model: "Room", match: { itemType: "room" }, select: "name itemType" },
-      { path: "item", model: "Seat", match: { itemType: "seat" }, select: "name itemType" },
-      { path: "item", model: "Equipment", match: { itemType: "equipment" }, select: "name itemType" },
-    ])
     .populate("attendees", "name email")
+    .populate({
+      path: "item",
+      populate: [
+        { path: "room", select: "name itemType" },
+        { path: "seat", select: "name itemType" },
+        { path: "equipment", select: "name itemType" },
+      ],
+    })
     .sort({ itemType: 1, startAt: 1 });
 
   if (userReservations.length === 0) {
@@ -89,9 +92,7 @@ export const getReservationsByTypeAndDate = async (
     $or: [{ startAt: { $gte: startOfDay, $lte: endOfDay } }, { endAt: { $gte: startOfDay, $lte: endOfDay } }],
   };
 
-  if (status) {
-    query.status = status;
-  }
+  if (status) query.status = status;
 
   const reservations: IReservation[] = await Reservation.find(query)
     .populate("user", "name email")
@@ -165,6 +166,7 @@ export const updateReservation = async (
 ): Promise<void> => {
   const { reservationId } = req.params;
   const { startAt, endAt } = req.body;
+  const status = req.body.status;
 
   // 예약 존재여부 확인
   const targetReservation: IReservation | null = await Reservation.findById(reservationId).select("startAt endAt item");
@@ -173,31 +175,38 @@ export const updateReservation = async (
     return;
   }
 
-  // 기존 startAt, endAt 값을 가져옴
-  const existingStartAt = targetReservation.startAt;
-  const existingEndAt = targetReservation.endAt;
-
   // startAt이나 endAt 중 하나만 수정된 경우 기존 값을 유지
-  const finalStartAt = startAt ? startAt : existingStartAt;
-  const finalEndAt = endAt ? endAt : existingEndAt;
+  const finalStartAt = startAt ? startAt : targetReservation.startAt;
+  let finalEndAt = endAt ? endAt : targetReservation.endAt;
 
-  if (!isMinuteValid(finalStartAt)) {
-    res.status(400).json({ message: "startAt 시간은 10분 단위로 설정해야 합니다." });
-    return;
-  }
-  if (!isMinuteValid(finalEndAt)) {
-    res.status(400).json({ message: "endAt 시간은 10분 단위로 설정해야 합니다." });
-    return;
-  }
-  if (finalStartAt >= finalEndAt) {
-    res.status(400).json({ message: "시작 시간은 종료 시간보다 이전이어야 합니다." });
-    return;
-  }
-  const itemId = (targetReservation.item as string).toString();
-  const overlappingReservation = await isOverlappedReservation(itemId, finalStartAt, finalEndAt, targetReservation._id);
-  if (overlappingReservation) {
-    res.status(409).json({ message: "해당 시간에 이미 예약이 존재합니다." });
-    return;
+  if (status === "completed") {
+    // 종료 시간이 현재 시간의 다음 10분으로 설정
+    const currentTime = new Date();
+    const nextRoundedTime = new Date(Math.ceil(currentTime.getTime() / (10 * 60 * 1000)) * (10 * 60 * 1000));
+    finalEndAt = nextRoundedTime;
+  } else if (status !== "canceled") {
+    // 일반 예약일 경우, 유효성 검사 및 중복 검사
+    if (!isMinuteValid(finalStartAt) || !isMinuteValid(finalEndAt)) {
+      res.status(400).json({ message: "시간은 10분 단위로 설정해야 합니다." });
+      return;
+    }
+    if (finalStartAt >= finalEndAt) {
+      res.status(400).json({ message: "시작 시간은 종료 시간보다 이전이어야 합니다." });
+      return;
+    }
+
+    // 중복 예약 검사
+    const itemId = (targetReservation.item as string).toString();
+    const overlappingReservation = await isOverlappedReservation(
+      itemId,
+      finalStartAt,
+      finalEndAt,
+      targetReservation._id,
+    );
+    if (overlappingReservation) {
+      res.status(409).json({ message: "해당 시간에 이미 예약이 존재합니다." });
+      return;
+    }
   }
 
   const updatedReservation: IReservation | null = await Reservation.findByIdAndUpdate(

--- a/apps/api/src/controllers/reservationControllers.ts
+++ b/apps/api/src/controllers/reservationControllers.ts
@@ -42,7 +42,12 @@ export const getUserReservations = async (
     startAt: { $gte: startOfDay, $lte: endOfDay },
   })
     .populate("user", "name email")
-    .populate("item", "name itemType")
+    .populate([
+      { path: "item", model: "Room", match: { itemType: "room" }, select: "name itemType" },
+      { path: "item", model: "Seat", match: { itemType: "seat" }, select: "name itemType" },
+      { path: "item", model: "Equipment", match: { itemType: "equipment" }, select: "name itemType" },
+    ])
+    .populate("attendees", "name email")
     .sort({ itemType: 1, startAt: 1 });
 
   if (userReservations.length === 0) {
@@ -70,7 +75,7 @@ export const getReservationsByTypeAndDate = async (
     return;
   }
 
-  const itemIds = await Item.find({ itemType }, "_id");
+  const itemIds = await Item.find({ type: itemType }, "_id");
   if (itemIds.length === 0) {
     res.status(404).json({ message: "해당 타입의 아이템이 없습니다." });
     return;
@@ -90,7 +95,8 @@ export const getReservationsByTypeAndDate = async (
 
   const reservations: IReservation[] = await Reservation.find(query)
     .populate("user", "name email")
-    .populate("item", "name")
+    .populate({ path: "item", model: itemType, select: "name itemType" })
+    .populate("attendees", "name email")
     .sort({ status: 1, startAt: 1 });
 
   res.status(200).json(reservations);
@@ -139,10 +145,8 @@ export const createReservation = async (
   }
 
   const newReservation = new Reservation({
-    userId,
-    itemId,
-    itemName: itemExists.name,
-    itemType: itemExists.itemType,
+    user: userId,
+    item: itemId,
     startAt,
     endAt,
     status: status ?? "reserved",
@@ -163,8 +167,7 @@ export const updateReservation = async (
   const { startAt, endAt } = req.body;
 
   // 예약 존재여부 확인
-  const targetReservation: IReservation | null =
-    await Reservation.findById(reservationId).select("startAt endAt itemId");
+  const targetReservation: IReservation | null = await Reservation.findById(reservationId).select("startAt endAt item");
   if (!targetReservation) {
     res.status(404).json({ message: "예약을 찾을 수 없습니다." });
     return;
@@ -186,18 +189,12 @@ export const updateReservation = async (
     res.status(400).json({ message: "endAt 시간은 10분 단위로 설정해야 합니다." });
     return;
   }
-
   if (finalStartAt >= finalEndAt) {
     res.status(400).json({ message: "시작 시간은 종료 시간보다 이전이어야 합니다." });
     return;
   }
-
-  const overlappingReservation = await isOverlappedReservation(
-    targetReservation.item._id,
-    finalStartAt,
-    finalEndAt,
-    targetReservation._id,
-  );
+  const itemId = (targetReservation.item as string).toString();
+  const overlappingReservation = await isOverlappedReservation(itemId, finalStartAt, finalEndAt, targetReservation._id);
   if (overlappingReservation) {
     res.status(409).json({ message: "해당 시간에 이미 예약이 존재합니다." });
     return;

--- a/apps/api/src/controllers/reservationControllers.ts
+++ b/apps/api/src/controllers/reservationControllers.ts
@@ -40,7 +40,10 @@ export const getUserReservations = async (
   const userReservations: IReservation[] = await Reservation.find({
     userId,
     startAt: { $gte: startOfDay, $lte: endOfDay },
-  }).sort({ itemType: 1, startAt: 1 });
+  })
+    .populate("user", "name email")
+    .populate("item", "name itemType")
+    .sort({ itemType: 1, startAt: 1 });
 
   if (userReservations.length === 0) {
     res.status(200).json({ message: "해당 유저의 예약이 없습니다.", reservations: [] });
@@ -52,7 +55,7 @@ export const getUserReservations = async (
 
 // 아이템 타입 및 날짜에 대한 예약 조회
 export const getReservationsByTypeAndDate = async (
-  req: Request<{ itemType: string }, IReservation[], undefined, { date?: string; status?: string }>,
+  req: Request<{ itemType: string }, IReservation[], unknown, { date?: string; status?: string }>,
   res: Response,
 ): Promise<void> => {
   const { itemType } = req.params;
@@ -85,7 +88,10 @@ export const getReservationsByTypeAndDate = async (
     query.status = status;
   }
 
-  const reservations: IReservation[] = await Reservation.find(query).sort({ status: 1, startAt: 1 });
+  const reservations: IReservation[] = await Reservation.find(query)
+    .populate("user", "name email")
+    .populate("item", "name")
+    .sort({ status: 1, startAt: 1 });
 
   res.status(200).json(reservations);
 };

--- a/apps/api/src/controllers/reservationControllers.ts
+++ b/apps/api/src/controllers/reservationControllers.ts
@@ -14,13 +14,19 @@ import isObjectIdValid from "../utils/isObjectIdValid";
 interface ReservationRequestBody {
   userId: string;
   itemId: string;
-  itemName: string;
+  itemType: string;
   startAt: Date;
   endAt: Date;
   status?: TReservationStatus;
   notes?: string;
   attendees?: string[];
 }
+
+const itemTypeToModel: Record<"room" | "seat" | "equipment", string> = {
+  room: "Room",
+  seat: "Seat",
+  equipment: "Equipment",
+};
 
 // 특정 유저의 오늘 날짜 예약 전체 조회(dashboards)
 export const getUserReservations = async (
@@ -46,9 +52,9 @@ export const getUserReservations = async (
     .populate({
       path: "item",
       populate: [
-        { path: "room", select: "name itemType" },
-        { path: "seat", select: "name itemType" },
-        { path: "equipment", select: "name itemType" },
+        { path: itemTypeToModel.room, select: "name itemType" },
+        { path: itemTypeToModel.seat, select: "name itemType" },
+        { path: itemTypeToModel.equipment, select: "name itemType" },
       ],
     })
     .sort({ itemType: 1, startAt: 1 });
@@ -66,8 +72,14 @@ export const getReservationsByTypeAndDate = async (
   req: Request<{ itemType: string }, IReservation[], unknown, { date?: string; status?: string }>,
   res: Response,
 ): Promise<void> => {
-  const { itemType } = req.params;
   const { date, status } = req.query;
+
+  const itemType = req.params.itemType as keyof typeof itemTypeToModel;
+
+  if (!(itemType in itemTypeToModel)) {
+    res.status(400).json({ message: "유효하지 않은 아이템 타입입니다." });
+    return;
+  }
 
   let searchDate = date;
   if (!searchDate) {
@@ -78,17 +90,11 @@ export const getReservationsByTypeAndDate = async (
     return;
   }
 
-  const itemIds = await Item.find({ type: itemType }, "_id");
-  if (itemIds.length === 0) {
-    res.status(404).json({ message: "해당 타입의 아이템이 없습니다." });
-    return;
-  }
-
   const targetDate = new Date(`${searchDate}T00:00:00Z`);
   const { startOfDay, endOfDay } = getStartAndEndOfDay(targetDate);
 
   const query: FilterQuery<IReservation> = {
-    itemId: { $in: itemIds },
+    itemType,
     $or: [{ startAt: { $gte: startOfDay, $lte: endOfDay } }, { endAt: { $gte: startOfDay, $lte: endOfDay } }],
   };
 
@@ -96,7 +102,7 @@ export const getReservationsByTypeAndDate = async (
 
   const reservations: IReservation[] = await Reservation.find(query)
     .populate("user", "name email")
-    .populate({ path: "item", model: itemType, select: "name itemType" })
+    .populate({ path: "item", model: itemTypeToModel[itemType], select: "name" })
     .populate("attendees", "name email")
     .sort({ status: 1, startAt: 1 });
 
@@ -109,7 +115,7 @@ export const createReservation = async (
   res: Response,
 ): Promise<void> => {
   const { itemId } = req.params;
-  const { userId, startAt, endAt, status, notes, attendees } = req.body;
+  const { userId, itemType, startAt, endAt, status, notes, attendees } = req.body;
 
   if (!isObjectIdValid(userId)) {
     res.status(400).json({ message: "유효하지 않은 사용자 ID입니다." });
@@ -148,6 +154,7 @@ export const createReservation = async (
   const newReservation = new Reservation({
     user: userId,
     item: itemId,
+    itemType,
     startAt,
     endAt,
     status: status ?? "reserved",

--- a/apps/api/src/models/reservationModel.ts
+++ b/apps/api/src/models/reservationModel.ts
@@ -33,7 +33,7 @@ const ReservationSchema: Schema = new Schema(
     },
     status: { type: String, enum: ReservationStatus, required: true },
     notes: { type: String },
-    attendees: { type: [Schema.Types.ObjectId], ref: "User" },
+    attendees: [{ type: Schema.Types.ObjectId, ref: "User" }],
   },
   {
     timestamps: true,

--- a/apps/api/src/models/reservationModel.ts
+++ b/apps/api/src/models/reservationModel.ts
@@ -15,8 +15,11 @@ const ReservationSchema: Schema = new Schema(
       required: true,
       validate: {
         validator(this: ReservationDoc, startAt: Date): boolean {
-          const timeWithBuffer = new Date(new Date().getTime() - TEN_MIN_BUFFER);
-          return startAt >= timeWithBuffer; // 예약 시간이 현재 시간 이후인지 확인(10분 여유)
+          if (this.status === "reserved") {
+            const timeWithBuffer = new Date(new Date().getTime() - TEN_MIN_BUFFER);
+            return startAt >= timeWithBuffer;
+          } // 예약 시간이 현재 시간 이후인지 확인(10분 여유)
+          return true;
         },
         message: "시작 시간은 10분 전까지 설정 가능합니다.",
       },
@@ -26,7 +29,11 @@ const ReservationSchema: Schema = new Schema(
       required: true,
       validate: {
         validator(this: ReservationDoc, endAt: Date): boolean {
-          return endAt > this.startAt; // 종료 시간이 시작 시간보다 이후여야 함
+          if (this.status === "reserved") {
+            return endAt > this.startAt;
+          }
+          // 종료 시간이 시작 시간보다 이후여야 함
+          return true;
         },
         message: "종료 시간은 시작 시간 이후로 설정 가능합니다.",
       },

--- a/apps/api/src/models/reservationModel.ts
+++ b/apps/api/src/models/reservationModel.ts
@@ -7,10 +7,9 @@ const TEN_MIN_BUFFER = 10 * 60 * 1000;
 
 const ReservationSchema: Schema = new Schema(
   {
-    userId: { type: String, required: true },
-    itemId: { type: String, required: true },
-    itemName: { type: String, required: true },
-    itemType: { type: String, required: true },
+    user: { type: Schema.Types.ObjectId, required: true, ref: "User" },
+    item: { type: Schema.Types.ObjectId, required: true },
+    itemType: { type: String, enum: ["room", "seat", "equipment"], required: true },
     startAt: {
       type: Date,
       required: true,
@@ -34,7 +33,7 @@ const ReservationSchema: Schema = new Schema(
     },
     status: { type: String, enum: ReservationStatus, required: true },
     notes: { type: String },
-    attendees: { type: [String] },
+    attendees: { type: [Schema.Types.ObjectId], ref: "User" },
   },
   {
     timestamps: true,

--- a/apps/api/src/utils/isOverlappedReservation.ts
+++ b/apps/api/src/utils/isOverlappedReservation.ts
@@ -9,7 +9,7 @@ export const isOverlappedReservation = async (
   excludeReservationId?: string,
 ): Promise<boolean> => {
   const query: FilterQuery<IReservation> = {
-    itemId,
+    item: itemId,
     status: "reserved",
     $or: [
       // 신규 startAt < 기존 endAt && 신규 endAt > 기존 startAt

--- a/packages/types/src/itemType.ts
+++ b/packages/types/src/itemType.ts
@@ -1,3 +1,5 @@
+import { ICategory } from "./categoryType";
+
 export const ItemStatus = ["available", "reserved", "in-use", "unavailable"] as const; // 예약가능, 예약됨, 대여중, 사용불가
 export type TItemStatus = (typeof ItemStatus)[number];
 
@@ -16,7 +18,7 @@ export interface TBaseItem {
 
 export interface IRoom extends TBaseItem {
   itemType: "room";
-  category: string;
+  category: ICategory;
   location?: string;
   capacity?: number;
 }
@@ -27,5 +29,5 @@ export interface ISeat extends TBaseItem {
 
 export interface IEquipment extends TBaseItem {
   itemType: "equipment";
-  category: string;
+  category: ICategory;
 }

--- a/packages/types/src/reservationType.ts
+++ b/packages/types/src/reservationType.ts
@@ -1,7 +1,7 @@
 import { IEquipment, IRoom, ISeat } from "./itemType";
 import { IUser } from "./userType";
 
-export const ReservationStatus = ["reserved", "cancelled", "completed"] as const; // 예약됨, 취소, 완료
+export const ReservationStatus = ["reserved", "canceled", "completed"] as const; // 예약됨, 취소, 완료
 export type TReservationStatus = (typeof ReservationStatus)[number];
 
 export interface IReservation {

--- a/packages/types/src/reservationType.ts
+++ b/packages/types/src/reservationType.ts
@@ -1,3 +1,6 @@
+import { IEquipment, IRoom, ISeat } from "./itemType";
+import { IUser } from "./userType";
+
 export const ReservationStatus = ["reserved", "cancelled", "completed"] as const; // 예약됨, 취소, 완료
 export type TReservationStatus = (typeof ReservationStatus)[number];
 
@@ -5,15 +8,14 @@ export type UserId = string;
 
 export interface IReservation {
   _id: string;
-  userId: UserId; // 예약한 사용자 ID (User의 id)
-  itemId: string; // 예약된 리소스 ID (Item의 id)
-  itemName: string; // 예약된 리소스 Name (Item의 name)
-  itemType: string;
+  user: IUser; // 예약한 사용자 (User)
+  item: IRoom | ISeat | IEquipment; // 예약된 리소스 (Item)
+  itemType: "room" | "seat" | "equipment";
   startAt: Date;
   endAt: Date;
   status: TReservationStatus;
   createdAt: Date;
   updatedAt: Date;
   notes?: string; // Optional
-  attendees?: UserId[]; // Optional 참여자 ID (User의 id)
+  attendees?: IUser[]; // Optional 참여자 (User)
 }

--- a/packages/types/src/reservationType.ts
+++ b/packages/types/src/reservationType.ts
@@ -4,12 +4,10 @@ import { IUser } from "./userType";
 export const ReservationStatus = ["reserved", "cancelled", "completed"] as const; // 예약됨, 취소, 완료
 export type TReservationStatus = (typeof ReservationStatus)[number];
 
-export type UserId = string;
-
 export interface IReservation {
   _id: string;
   user: IUser; // 예약한 사용자 (User)
-  item: IRoom | ISeat | IEquipment; // 예약된 리소스 (Item)
+  item: string | IRoom | ISeat | IEquipment; // 예약된 리소스 (Item)
   itemType: "room" | "seat" | "equipment";
   startAt: Date;
   endAt: Date;


### PR DESCRIPTION
## 🚀 작업 내용
- response 데이터 스키마 중첩구조로 변경했습니다.
- 조회 쿼리 컨트롤러 함수 `populate`로 db 호출 횟수 줄여봤습니다.
- 예약 `status` 필드 수정 로직 추가
  - `completed`, `canceled `로 변경 시 + 예약 상태가 `completed`, `canceled `인 경우 시간 포맷 유효성검사 제외되도록 예외처리 하였습니다.

## 📝 참고 사항
- 스키마나 타입 변경이 있어서 `build` 한번씩 해주십쇼!

## 🖼️ 스크린샷

## 🚨 관련 이슈 (이슈 번호)
- #102 

## ✅ 체크리스트

- [x] Code Review 요청
- [x] Label 설정
- [x] PR 제목 규칙에 맞는지 확인


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **새로운 기능**
	- 아이템 조회 시 카테고리 이름 포함.
	- 예약 생성 시 아이템 타입을 사용하도록 변경.
	- 예약 상태 업데이트 로직 개선.
	- 카테고리 삭제 시 예약 확인 로직 개선.

- **버그 수정**
	- 예약 중복 확인 로직 수정.

- **문서화**
	- 인터페이스 및 타입의 구조 개선으로 타입 안전성 향상.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->