### PR TITLE
[Fix] 예약 조회 시 시간 범위 계산 로직, 유틸함수 수정

### DIFF
--- a/apps/api/src/controllers/reservationControllers.ts
+++ b/apps/api/src/controllers/reservationControllers.ts
@@ -64,7 +64,7 @@ export const getUserReservations = async (
     return;
   }
 
-  const today = new Date();
+  const today = new Date().toLocaleDateString("en-CA");
   const { startOfDay, endOfDay } = getStartAndEndOfDay(today);
 
   const userReservations: IReservation[] = await Reservation.find({
@@ -140,17 +140,13 @@ export const getReservationsByTypeAndDate = async (
     return;
   }
 
-  let searchDate = date;
-  if (!searchDate) {
-    const today = new Date();
-    searchDate = today.toISOString().split("T")[0];
-  } else if (!isValidDateFormat(searchDate)) {
+  const searchDate = date ?? new Date().toLocaleDateString("en-CA");
+  if (!isValidDateFormat(searchDate)) {
     res.status(400).json({ message: "날짜 형식이 잘못되었습니다. YYYY-MM-DD 형식으로 입력해주세요." });
     return;
   }
 
-  const targetDate = new Date(`${searchDate}T00:00:00Z`);
-  const { startOfDay, endOfDay } = getStartAndEndOfDay(targetDate);
+  const { startOfDay, endOfDay } = getStartAndEndOfDay(searchDate);
 
   const query: FilterQuery<IReservation> = {
     itemType,

--- a/apps/api/src/utils/getStartAndEndOfDay.ts
+++ b/apps/api/src/utils/getStartAndEndOfDay.ts
@@ -1,8 +1,11 @@
-export const getStartAndEndOfDay = (date: Date): { startOfDay: Date; endOfDay: Date } => {
-  // 한국 로컬타임 기준으로 설정
-  const startOfDay = new Date(date);
-  startOfDay.setUTCHours(15, 0, 0, 0); // 시작 시간을 전날 15:00로 설정
-  const endOfDay = new Date(date);
-  endOfDay.setUTCHours(14, 59, 59, 999); // 종료 시간을 당일 14:59로 설정
-  return { startOfDay, endOfDay };
+export const getStartAndEndOfDay = (dateString: string): { startOfDay: Date; endOfDay: Date } => {
+  // 유저의 로컬 타임존을 자동으로 감지하여 startOfDay와 endOfDay를 UTC 기준으로 설정
+  const localStartOfDay = new Date(`${dateString}T00:00:00`);
+  const localEndOfDay = new Date(`${dateString}T23:59:59`);
+
+  // 로컬 기준 시간대를 UTC로 변환
+  const startOfDayUTC = new Date(localStartOfDay.toISOString());
+  const endOfDayUTC = new Date(localEndOfDay.toISOString());
+
+  return { startOfDay: startOfDayUTC, endOfDay: endOfDayUTC };
 };


### PR DESCRIPTION
## 🚀 작업 내용
- 예약 조회 시 시간 범위 계산 로직, 유틸함수(`getStartAndEndOfDay`) 수정

## 📝 참고 사항
- 예약 조회 로직 문제가 있어서 수정했습니다
서버쪽에서는 핸들링 전부 utc로 하니까
조회(get)할 때 날짜(예를들어 2024-11-09)만 던져주면 해당 날짜로 로컬타임 00시, 23시59분 생성 하고
그 로컬타임을 utc로 변환해서 변환된 시간 내에 들어가는 예약 전부 반환 해주는걸로 했어요
렌더링 해주실 때에는 utc를 현재 로컬타임으로 변환 해서 보여주시면 될 것 같습니당

프론트에서 post 하는 경우에도 마찬가지로 로컬타임 utc로 변환해서 보내주시면 됩니다

## 🖼️ 스크린샷

## 🚨 관련 이슈 (이슈 번호)
- #143 

## ✅ 체크리스트
- [x] Code Review 요청
- [x] Label 설정
- [x] PR 제목 규칙에 맞는지 확인


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
	- 예약 관련 API의 날짜 처리 및 검증 로직 개선.
	- 날짜 문자열 형식("YYYY-MM-DD")으로 처리하여 사용자 지역 시간대에 맞게 자동 조정.

- **버그 수정**
	- 날짜 검색 로직 간소화 및 오류 메시지 구조 개선.

- **문서화**
	- 함수의 파라미터 타입을 `Date`에서 `string`으로 변경하여 명확성 향상.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->